### PR TITLE
Stdev al den t163 make commands atomic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -142,7 +142,6 @@ linters-settings:
 linters:
   enable:
     - golint
-    - goimports
     - varcheck
     - unparam
     - deadcode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add a new `Devicer` implementation (`Sequencer`) with atomics commands.
 - Add flag `walletType` for `addressGen`, `signMessage` and `transactionSign`.
 - Add travis CD instructions for github releases.
 - Add BitEncodedFlags to encode/decode flags from/to a string.

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ check-version:
 check: lint test ## Perform self-tests
 
 lint: ## Run linters. Use make install-linters first.
-	vendorcheck ./...
 	golangci-lint run -c .golangci.yml ./...
+	vendorcheck ./...
 
 format: ## Formats the code. Must have goimports installed (use make install-linters).
 	goimports -w -local github.com/fibercrypto/skywallet-go ./cmd

--- a/src/cli/address_gen.go
+++ b/src/cli/address_gen.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
 	messages "github.com/fibercrypto/skywallet-protob/go"
 
 	gcli "github.com/urfave/cli"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func addressGenCmd() gcli.Command {
@@ -53,18 +49,7 @@ func addressGenCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.AddressGen(uint32(addressN), uint32(startIndex), confirmAddress, walletType)
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to get address")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_ResponseSkycoinAddress) {
-				msgStr, err := skyWallet.DecodeResponseSkycoinAddress(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to get address", messages.MessageType_MessageType_ResponseSkycoinAddress)
 		},
 	}
 }

--- a/src/cli/address_gen.go
+++ b/src/cli/address_gen.go
@@ -3,10 +3,6 @@ package cli
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
-	"os"
-	"runtime"
-
 	messages "github.com/fibercrypto/skywallet-protob/go"
 
 	gcli "github.com/urfave/cli"
@@ -52,18 +48,10 @@ func addressGenCmd() gcli.Command {
 			addressN := c.Int("addressN")
 			startIndex := c.Int("startIndex")
 			confirmAddress := c.Bool("confirmAddress")
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
 				return
 			}
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-			sq := proxy.NewSequencer(device, false)
 			msg, err := sq.AddressGen(uint32(addressN), uint32(startIndex), confirmAddress, walletType)
 			if err != nil {
 				logrus.WithError(err).Errorln("unable to get address")

--- a/src/cli/address_gen.go
+++ b/src/cli/address_gen.go
@@ -70,7 +70,7 @@ func addressGenCmd() gcli.Command {
 			} else if msg.Kind == uint16(messages.MessageType_MessageType_ResponseSkycoinAddress) {
 				msgStr, err := skyWallet.DecodeResponseSkycoinAddress(msg)
 				if err != nil {
-					logrus.WithError(err).Errorln("unable to get address")
+					logrus.WithError(err).Errorln("unable to decode response")
 					return
 				}
 				fmt.Println(msgStr)

--- a/src/cli/apply_settings.go
+++ b/src/cli/apply_settings.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func applySettingsCmd() gcli.Command {
@@ -51,18 +47,7 @@ func applySettingsCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.ApplySettings(usePassphrase, label, language)
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to apply settings")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-				msgStr, err := skyWallet.DecodeSuccessMsg(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to apply settings", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/cli/apply_settings.go
+++ b/src/cli/apply_settings.go
@@ -3,10 +3,6 @@ package cli
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
-	"os"
-	"runtime"
-
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
@@ -45,23 +41,15 @@ func applySettingsCmd() gcli.Command {
 			passphrase := c.String("usePassphrase")
 			label := c.String("label")
 			language := c.String("language")
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
-				return
-			}
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
 			usePassphrase, _err := parseBool(passphrase)
 			if _err != nil {
 				log.Errorln("Valid values for usePassphrase are true or false")
 				return
 			}
-			sq := proxy.NewSequencer(device, false)
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
+				return
+			}
 			msg, err := sq.ApplySettings(usePassphrase, label, language)
 			if err != nil {
 				logrus.WithError(err).Errorln("unable to apply settings")

--- a/src/cli/backup.go
+++ b/src/cli/backup.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func backupCmd() gcli.Command {
@@ -30,18 +26,7 @@ func backupCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.Backup()
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to create backup")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-				msgStr, err := skyWallet.DecodeSuccessMsg(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to create backup", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/cli/backup.go
+++ b/src/cli/backup.go
@@ -3,10 +3,6 @@ package cli
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
-	"os"
-	"runtime"
-
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
@@ -29,20 +25,10 @@ func backupCmd() gcli.Command {
 			},
 		},
 		Action: func(c *gcli.Context) {
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
 				return
 			}
-			defer device.Close()
-
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-			sq := proxy.NewSequencer(device, false)
 			msg, err := sq.Backup()
 			if err != nil {
 				logrus.WithError(err).Errorln("unable to create backup")

--- a/src/cli/cancel.go
+++ b/src/cli/cancel.go
@@ -2,9 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
-	"runtime"
-
 	gcli "github.com/urfave/cli"
 
 	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
@@ -25,32 +22,20 @@ func cancelCmd() gcli.Command {
 			},
 		},
 		Action: func(c *gcli.Context) {
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
 				return
 			}
-			defer device.Close()
-
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-
-			msg, err := device.Cancel()
+			msg, err := sq.Cancel()
 			if err != nil {
 				log.Error(err)
 				return
 			}
-
 			responseMsg, err := skyWallet.DecodeSuccessOrFailMsg(msg)
 			if err != nil {
 				log.Error(err)
 				return
 			}
-
 			fmt.Println(responseMsg)
 		},
 	}

--- a/src/cli/cancel.go
+++ b/src/cli/cancel.go
@@ -1,10 +1,8 @@
 package cli
 
 import (
-	"fmt"
+	messages "github.com/fibercrypto/skywallet-protob/go"
 	gcli "github.com/urfave/cli"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func cancelCmd() gcli.Command {
@@ -27,16 +25,7 @@ func cancelCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.Cancel()
-			if err != nil {
-				log.Error(err)
-				return
-			}
-			responseMsg, err := skyWallet.DecodeSuccessOrFailMsg(msg)
-			if err != nil {
-				log.Error(err)
-				return
-			}
-			fmt.Println(responseMsg)
+			handleFinalResponse(msg, err, "unable to cancel", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/cli/check_message_signature.go
+++ b/src/cli/check_message_signature.go
@@ -1,10 +1,8 @@
 package cli
 
 import (
-	"fmt"
+	messages "github.com/fibercrypto/skywallet-protob/go"
 	gcli "github.com/urfave/cli"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func checkMessageSignatureCmd() gcli.Command {
@@ -42,18 +40,7 @@ func checkMessageSignatureCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.CheckMessageSignature(message, signature, address)
-			if err != nil {
-				log.Error(err)
-				return
-			}
-
-			responseMsg, err := skyWallet.DecodeSuccessOrFailMsg(msg)
-			if err != nil {
-				log.Error(err)
-				return
-			}
-
-			fmt.Println(responseMsg)
+			handleFinalResponse(msg, err, "unable to check message signature", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/cli/check_message_signature.go
+++ b/src/cli/check_message_signature.go
@@ -2,9 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
-	"runtime"
-
 	gcli "github.com/urfave/cli"
 
 	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
@@ -40,22 +37,11 @@ func checkMessageSignatureCmd() gcli.Command {
 			message := c.String("message")
 			signature := c.String("signature")
 			address := c.String("address")
-
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
 				return
 			}
-			defer device.Close()
-
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-
-			msg, err := device.CheckMessageSignature(message, signature, address)
+			msg, err := sq.CheckMessageSignature(message, signature, address)
 			if err != nil {
 				log.Error(err)
 				return

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"fmt"
-
 	"github.com/skycoin/skycoin/src/util/logging"
 	gcli "github.com/urfave/cli"
 )

--- a/src/cli/features.go
+++ b/src/cli/features.go
@@ -1,15 +1,8 @@
 package cli
 
 import (
-	"encoding/json"
-	"github.com/Sirupsen/logrus"
-	"github.com/micro/protobuf/proto"
-	gcli "github.com/urfave/cli"
-	"os"
-
 	messages "github.com/fibercrypto/skywallet-protob/go"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
+	gcli "github.com/urfave/cli"
 )
 
 func featuresCmd() gcli.Command {
@@ -32,28 +25,7 @@ func featuresCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.GetFeatures()
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to get features")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_Features) {
-				features := &messages.Features{}
-				if err = proto.Unmarshal(msg.Data, features); err != nil {
-					log.Error(err)
-					return
-				}
-				enc := json.NewEncoder(os.Stdout)
-				if err = enc.Encode(features); err != nil {
-					log.Errorln(err)
-					return
-				}
-				ff := skyWallet.NewFirmwareFeatures(uint64(*features.FirmwareFeatures))
-				if err := ff.Unmarshal(); err != nil {
-					log.Errorln(err)
-					return
-				}
-				log.Printf("\n\nFirmware features:\n%s", ff)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to get features", messages.MessageType_MessageType_Features)
 		},
 	}
 }

--- a/src/cli/features.go
+++ b/src/cli/features.go
@@ -3,12 +3,9 @@ package cli
 import (
 	"encoding/json"
 	"github.com/Sirupsen/logrus"
-	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
 	"github.com/micro/protobuf/proto"
-	"os"
-	"runtime"
-
 	gcli "github.com/urfave/cli"
+	"os"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
 
@@ -30,18 +27,10 @@ func featuresCmd() gcli.Command {
 			},
 		},
 		Action: func(c *gcli.Context) {
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
 				return
 			}
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-			sq := proxy.NewSequencer(device, false)
 			msg, err := sq.GetFeatures()
 			if err != nil {
 				logrus.WithError(err).Errorln("unable to get features")

--- a/src/cli/firmware_update.go
+++ b/src/cli/firmware_update.go
@@ -6,8 +6,6 @@ import (
 	"io/ioutil"
 
 	gcli "github.com/urfave/cli"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func firmwareUpdate() gcli.Command {
@@ -24,12 +22,6 @@ func firmwareUpdate() gcli.Command {
 		},
 		OnUsageError: onCommandUsageError(name),
 		Action: func(c *gcli.Context) {
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeUSB)
-			if device == nil {
-				return
-			}
-			defer device.Close()
-
 			filePath := c.String("file")
 			fmt.Printf("File : %s\n", filePath)
 			firmware, err := ioutil.ReadFile(filePath)
@@ -37,7 +29,11 @@ func firmwareUpdate() gcli.Command {
 				panic(err)
 			}
 			fmt.Printf("Hash: %x\n", sha256.Sum256(firmware[0x100:]))
-			err = device.FirmwareUpload(firmware, sha256.Sum256(firmware[0x100:]))
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
+				return
+			}
+			err = sq.FirmwareUpload(firmware, sha256.Sum256(firmware[0x100:]))
 			if err != nil {
 				log.Error(err)
 				return

--- a/src/cli/generate_mnemonic.go
+++ b/src/cli/generate_mnemonic.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
 	messages "github.com/fibercrypto/skywallet-protob/go"
 
 	gcli "github.com/urfave/cli"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func generateMnemonicCmd() gcli.Command {
@@ -41,18 +37,7 @@ func generateMnemonicCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.GenerateMnemonic(wordCount, usePassphrase)
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to generate mnemonic")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-				msgStr, err := skyWallet.DecodeSuccessMsg(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to generate mnemonic", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/cli/generate_mnemonic.go
+++ b/src/cli/generate_mnemonic.go
@@ -3,10 +3,6 @@ package cli
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
-	"os"
-	"runtime"
-
 	messages "github.com/fibercrypto/skywallet-protob/go"
 
 	gcli "github.com/urfave/cli"
@@ -40,21 +36,10 @@ func generateMnemonicCmd() gcli.Command {
 		Action: func(c *gcli.Context) {
 			usePassphrase := c.Bool("usePassphrase")
 			wordCount := uint32(c.Uint64("wordCount"))
-
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
 				return
 			}
-			defer device.Close()
-
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-			sq := proxy.NewSequencer(device, false)
 			msg, err := sq.GenerateMnemonic(wordCount, usePassphrase)
 			if err != nil {
 				logrus.WithError(err).Errorln("unable to generate mnemonic")

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -653,7 +653,7 @@ func TestSetPinCode(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, cmd.Start())
 
-	var fail = false
+	var fail1, fail2 = false, false
 	var stdInDone = false
 
 	go func() {
@@ -670,7 +670,7 @@ func TestSetPinCode(t *testing.T) {
 				stdInDone = true
 			} else if stdInDone {
 				if m == "mismatch" {
-					fail = true
+					fail1 = true
 					break
 				}
 			}
@@ -683,14 +683,14 @@ func TestSetPinCode(t *testing.T) {
 		for scanner.Scan() {
 			log.Errorln(scanner.Text())
 			if len(scanner.Text()) > 0 {
-				fail = true
+				fail2 = true
 			}
 		}
 	}()
 
 	err = cmd.Wait()
 	require.NoError(t, err)
-	require.True(t, fail)
+	require.True(t, fail1 || fail2)
 }
 
 func TestRemovePinCode(t *testing.T) {

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -662,8 +662,8 @@ func TestSetPinCode(t *testing.T) {
 		scanner.Split(bufio.ScanWords)
 		for scanner.Scan() {
 			m := scanner.Text()
-			if m == "response:" {
-				time.Sleep(1 * time.Second)
+			if m == "pin:" {
+				time.Sleep(time.Second)
 				_, err := stdInPipe.Write([]byte("123\n"))
 				require.NoError(t, err)
 
@@ -682,6 +682,9 @@ func TestSetPinCode(t *testing.T) {
 		scanner.Split(bufio.ScanWords)
 		for scanner.Scan() {
 			log.Errorln(scanner.Text())
+			if len(scanner.Text()) > 0 {
+				fail = true
+			}
 		}
 	}()
 

--- a/src/cli/recovery.go
+++ b/src/cli/recovery.go
@@ -3,10 +3,6 @@ package cli
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
-	"os"
-	"runtime"
-
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
@@ -42,20 +38,6 @@ func recoveryCmd() gcli.Command {
 		},
 		OnUsageError: onCommandUsageError(name),
 		Action: func(c *gcli.Context) {
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
-				return
-			}
-			defer device.Close()
-
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-
 			passphrase := c.String("usePassphrase")
 			usePassphrase, _err := parseBool(passphrase)
 			if _err != nil {
@@ -64,7 +46,10 @@ func recoveryCmd() gcli.Command {
 			}
 			dryRun := c.Bool("dryRun")
 			wordCount := uint32(c.Uint64("wordCount"))
-			sq := proxy.NewSequencer(device, false)
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
+				return
+			}
 			msg, err := sq.Recovery(wordCount, usePassphrase, dryRun)
 			if err != nil {
 				logrus.WithError(err).Errorln("unable to recover device")

--- a/src/cli/recovery.go
+++ b/src/cli/recovery.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func recoveryCmd() gcli.Command {
@@ -51,18 +47,7 @@ func recoveryCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.Recovery(wordCount, usePassphrase, dryRun)
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to recover device")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-				msgStr, err := skyWallet.DecodeSuccessMsg(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to recovery device", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/cli/remove_pin_code.go
+++ b/src/cli/remove_pin_code.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func removePinCode() gcli.Command {
@@ -25,7 +21,6 @@ func removePinCode() gcli.Command {
 		},
 		OnUsageError: onCommandUsageError(name),
 		Action: func(c *gcli.Context) {
-			var pinEnc string
 			removePin := new(bool)
 			*removePin = true
 			sq, err := createDevice(c.String("deviceType"))
@@ -33,37 +28,7 @@ func removePinCode() gcli.Command {
 				return
 			}
 			msg, err := sq.ChangePin(removePin)
-			if err != nil {
-				log.Error(err)
-				return
-			}
-
-			if msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
-				msg, err = sq.ButtonAck()
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-
-			for msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) {
-				fmt.Printf("PinMatrixRequest response: ")
-				fmt.Scanln(&pinEnc)
-				msg, err = sq.PinMatrixAck(pinEnc)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-
-			// handle success or failure msg
-			respMsg, err := skyWallet.DecodeSuccessOrFailMsg(msg)
-			if err != nil {
-				log.Error(err)
-				return
-			}
-
-			fmt.Println(respMsg)
+			handleFinalResponse(msg, err, "unable to remove pin", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/cli/set_mnemonic.go
+++ b/src/cli/set_mnemonic.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
 	messages "github.com/fibercrypto/skywallet-protob/go"
 
 	gcli "github.com/urfave/cli"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func setMnemonicCmd() gcli.Command {
@@ -35,18 +31,7 @@ func setMnemonicCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.SetMnemonic(mnemonic)
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to set mnemonic")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-				msgStr, err := skyWallet.DecodeSuccessMsg(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to set mnemonic", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/cli/set_mnemonic.go
+++ b/src/cli/set_mnemonic.go
@@ -3,10 +3,6 @@ package cli
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
-	"os"
-	"runtime"
-
 	messages "github.com/fibercrypto/skywallet-protob/go"
 
 	gcli "github.com/urfave/cli"
@@ -33,20 +29,11 @@ func setMnemonicCmd() gcli.Command {
 		},
 		OnUsageError: onCommandUsageError(name),
 		Action: func(c *gcli.Context) {
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
+			mnemonic := c.String("mnemonic")
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
 				return
 			}
-			defer device.Close()
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-			mnemonic := c.String("mnemonic")
-			sq := proxy.NewSequencer(device, false)
 			msg, err := sq.SetMnemonic(mnemonic)
 			if err != nil {
 				logrus.WithError(err).Errorln("unable to set mnemonic")

--- a/src/cli/set_pin_code.go
+++ b/src/cli/set_pin_code.go
@@ -3,9 +3,6 @@ package cli
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
-	"os"
-	"runtime"
 
 	gcli "github.com/urfave/cli"
 
@@ -29,19 +26,10 @@ func setPinCode() gcli.Command {
 		},
 		OnUsageError: onCommandUsageError(name),
 		Action: func(c *gcli.Context) {
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
 				return
 			}
-			defer device.Close()
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-			sq := proxy.NewSequencer(device, false)
 			msg, err := sq.ChangePin(new(bool))
 			if err != nil {
 				logrus.WithError(err).Errorln("unable to create backup")

--- a/src/cli/set_pin_code.go
+++ b/src/cli/set_pin_code.go
@@ -1,14 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
-
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func setPinCode() gcli.Command {
@@ -31,18 +26,7 @@ func setPinCode() gcli.Command {
 				return
 			}
 			msg, err := sq.ChangePin(new(bool))
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to create backup")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-				msgStr, err := skyWallet.DecodeSuccessMsg(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to change pin", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/cli/sign_message.go
+++ b/src/cli/sign_message.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func signMessageCmd() gcli.Command {
@@ -46,18 +42,7 @@ func signMessageCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.SignMessage(1, addressIndex, message, walletType)
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to sign transaction")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_ResponseSkycoinSignMessage) {
-				msgStr, err := skyWallet.DecodeResponseSkycoinSignMessage(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to sign message", messages.MessageType_MessageType_ResponseSkycoinSignMessage)
 		},
 	}
 }

--- a/src/cli/transaction_sign.go
+++ b/src/cli/transaction_sign.go
@@ -2,14 +2,11 @@ package cli
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
 	"github.com/gogo/protobuf/proto"
 
 	gcli "github.com/urfave/cli"
 
 	messages "github.com/fibercrypto/skywallet-protob/go"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func transactionSignCmd() gcli.Command {
@@ -94,18 +91,7 @@ func transactionSignCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.TransactionSign(transactionInputs, transactionOutputs, walletType)
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to sign transaction")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_ResponseTransactionSign) {
-				msgStr, err := skyWallet.DecodeResponseTransactionSign(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to sign transaction", messages.MessageType_MessageType_ResponseTransactionSign)
 		},
 	}
 }

--- a/src/cli/utils.go
+++ b/src/cli/utils.go
@@ -2,6 +2,10 @@ package cli
 
 import (
 	"errors"
+	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
+	"github.com/fibercrypto/skywallet-go/src/skywallet"
+	"os"
+	"runtime"
 )
 
 func parseBool(s string) (*bool, error) {
@@ -17,4 +21,19 @@ func parseBool(s string) (*bool, error) {
 		return nil, errors.New("Invalid boolean argument")
 	}
 	return &b, nil
+}
+
+func createDevice(devType string) (skywallet.Devicer, error) {
+	device := skywallet.NewDevice(skywallet.DeviceTypeFromString(devType))
+	if device == nil {
+		return nil, errors.New("got null device")
+	}
+	if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skywallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
+		err := device.SetAutoPressButton(true, skywallet.ButtonRight)
+		if err != nil {
+			log.Error(err)
+			return nil, err
+		}
+	}
+	return proxy.NewSequencer(device, false), nil
 }

--- a/src/cli/utils.go
+++ b/src/cli/utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fibercrypto/skywallet-go/src/skywallet"
 	"github.com/fibercrypto/skywallet-go/src/skywallet/wire"
 	messages "github.com/fibercrypto/skywallet-protob/go"
-	"github.com/micro/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"os"
 	"runtime"
 )

--- a/src/cli/utils.go
+++ b/src/cli/utils.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
 	"github.com/fibercrypto/skywallet-go/src/skywallet"
 	"github.com/fibercrypto/skywallet-go/src/skywallet/wire"
@@ -44,68 +44,53 @@ func createDevice(devType string) (skywallet.Devicer, error) {
 	return proxy.NewSequencer(device, false), nil
 }
 
-func handleFinalResponse(msg wire.Message, err error, errMsg string, expectedMsgKind messages.MessageType) error {
+func handleFinalResponse(msg wire.Message, err error, errMsg string, expectedMsgKind messages.MessageType) {
 	if err != nil {
 		logrus.WithError(err).Errorln(errMsg)
-		return err
 	}
 	if msg.Kind != uint16(expectedMsgKind) {
-		logrus.Errorln(errMsg)
-		return errors.New("invalid state")
+		logrus.Errorln(errMsg + "invalid state")
 	}
 	switch messages.MessageType(msg.Kind) {
 	case messages.MessageType_MessageType_ResponseSkycoinAddress:
 		msgStr, err := skywallet.DecodeResponseSkycoinAddress(msg)
 		if err != nil {
 			logrus.WithError(err).Errorln("unable to decode response")
-			return err
 		}
 		fmt.Println(msgStr)
-		return nil
 	case messages.MessageType_MessageType_Success:
 		msgStr, err := skywallet.DecodeSuccessMsg(msg)
 		if err != nil {
 			logrus.WithError(err).Errorln("unable to decode response")
-			return err
 		}
 		fmt.Println(msgStr)
-		return nil
 	case messages.MessageType_MessageType_ResponseSkycoinSignMessage:
 		msgStr, err := skywallet.DecodeResponseSkycoinSignMessage(msg)
 		if err != nil {
 			logrus.WithError(err).Errorln("unable to decode response")
-			return err
 		}
 		fmt.Println(msgStr)
-		return nil
 	case messages.MessageType_MessageType_ResponseTransactionSign:
 		msgStr, err := skywallet.DecodeResponseTransactionSign(msg)
 		if err != nil {
 			logrus.WithError(err).Errorln("unable to decode response")
-			return err
 		}
 		fmt.Println(msgStr)
-		return nil
 	case messages.MessageType_MessageType_Features:
 		features := &messages.Features{}
 		if err = proto.Unmarshal(msg.Data, features); err != nil {
 			log.Error(err)
-			return err
 		}
 		enc := json.NewEncoder(os.Stdout)
 		if err = enc.Encode(features); err != nil {
 			log.Errorln(err)
-			return err
 		}
 		ff := skywallet.NewFirmwareFeatures(uint64(*features.FirmwareFeatures))
 		if err := ff.Unmarshal(); err != nil {
 			log.Errorln(err)
-			return err
 		}
 		log.Printf("\n\nFirmware features:\n%s", ff)
-		return nil
 	default:
 		logrus.Errorln("invalid state")
-		return errors.New("invalid state")
 	}
 }

--- a/src/cli/utils.go
+++ b/src/cli/utils.go
@@ -41,7 +41,11 @@ func createDevice(devType string) (skywallet.Devicer, error) {
 			return nil, err
 		}
 	}
-	return proxy.NewSequencer(device, false), nil
+	return proxy.NewSequencer(device, false, func() string{
+		var line string
+		fmt.Scanln(&line)
+		return line
+	}), nil
 }
 
 func handleFinalResponse(msg wire.Message, err error, errMsg string, expectedMsgKind messages.MessageType) {

--- a/src/cli/utils.go
+++ b/src/cli/utils.go
@@ -1,9 +1,15 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"github.com/Sirupsen/logrus"
 	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
 	"github.com/fibercrypto/skywallet-go/src/skywallet"
+	"github.com/fibercrypto/skywallet-go/src/skywallet/wire"
+	messages "github.com/fibercrypto/skywallet-protob/go"
+	"github.com/micro/protobuf/proto"
 	"os"
 	"runtime"
 )
@@ -36,4 +42,70 @@ func createDevice(devType string) (skywallet.Devicer, error) {
 		}
 	}
 	return proxy.NewSequencer(device, false), nil
+}
+
+func handleFinalResponse(msg wire.Message, err error, errMsg string, expectedMsgKind messages.MessageType) error {
+	if err != nil {
+		logrus.WithError(err).Errorln(errMsg)
+		return err
+	}
+	if msg.Kind != uint16(expectedMsgKind) {
+		logrus.Errorln(errMsg)
+		return errors.New("invalid state")
+	}
+	switch messages.MessageType(msg.Kind) {
+	case messages.MessageType_MessageType_ResponseSkycoinAddress:
+		msgStr, err := skywallet.DecodeResponseSkycoinAddress(msg)
+		if err != nil {
+			logrus.WithError(err).Errorln("unable to decode response")
+			return err
+		}
+		fmt.Println(msgStr)
+		return nil
+	case messages.MessageType_MessageType_Success:
+		msgStr, err := skywallet.DecodeSuccessMsg(msg)
+		if err != nil {
+			logrus.WithError(err).Errorln("unable to decode response")
+			return err
+		}
+		fmt.Println(msgStr)
+		return nil
+	case messages.MessageType_MessageType_ResponseSkycoinSignMessage:
+		msgStr, err := skywallet.DecodeResponseSkycoinSignMessage(msg)
+		if err != nil {
+			logrus.WithError(err).Errorln("unable to decode response")
+			return err
+		}
+		fmt.Println(msgStr)
+		return nil
+	case messages.MessageType_MessageType_ResponseTransactionSign:
+		msgStr, err := skywallet.DecodeResponseTransactionSign(msg)
+		if err != nil {
+			logrus.WithError(err).Errorln("unable to decode response")
+			return err
+		}
+		fmt.Println(msgStr)
+		return nil
+	case messages.MessageType_MessageType_Features:
+		features := &messages.Features{}
+		if err = proto.Unmarshal(msg.Data, features); err != nil {
+			log.Error(err)
+			return err
+		}
+		enc := json.NewEncoder(os.Stdout)
+		if err = enc.Encode(features); err != nil {
+			log.Errorln(err)
+			return err
+		}
+		ff := skywallet.NewFirmwareFeatures(uint64(*features.FirmwareFeatures))
+		if err := ff.Unmarshal(); err != nil {
+			log.Errorln(err)
+			return err
+		}
+		log.Printf("\n\nFirmware features:\n%s", ff)
+		return nil
+	default:
+		logrus.Errorln("invalid state")
+		return errors.New("invalid state")
+	}
 }

--- a/src/cli/wipe.go
+++ b/src/cli/wipe.go
@@ -3,10 +3,6 @@ package cli
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/fibercrypto/skywallet-go/src/integration/proxy"
-	"os"
-	"runtime"
-
 	messages "github.com/fibercrypto/skywallet-protob/go"
 
 	gcli "github.com/urfave/cli"
@@ -29,20 +25,10 @@ func wipeCmd() gcli.Command {
 			},
 		},
 		Action: func(c *gcli.Context) {
-			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
-			if device == nil {
+			sq, err := createDevice(c.String("deviceType"))
+			if err != nil {
 				return
 			}
-			defer device.Close()
-
-			if os.Getenv("AUTO_PRESS_BUTTONS") == "1" && device.Driver.DeviceType() == skyWallet.DeviceTypeEmulator && runtime.GOOS == "linux" {
-				err := device.SetAutoPressButton(true, skyWallet.ButtonRight)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-			}
-			sq := proxy.NewSequencer(device, false)
 			msg, err := sq.Wipe()
 			if err != nil {
 				logrus.WithError(err).Errorln("unable to wipe the device")

--- a/src/cli/wipe.go
+++ b/src/cli/wipe.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
 	messages "github.com/fibercrypto/skywallet-protob/go"
 
 	gcli "github.com/urfave/cli"
-
-	skyWallet "github.com/fibercrypto/skywallet-go/src/skywallet"
 )
 
 func wipeCmd() gcli.Command {
@@ -30,18 +26,7 @@ func wipeCmd() gcli.Command {
 				return
 			}
 			msg, err := sq.Wipe()
-			if err != nil {
-				logrus.WithError(err).Errorln("unable to wipe the device")
-			} else if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-				msgStr, err := skyWallet.DecodeSuccessMsg(msg)
-				if err != nil {
-					logrus.WithError(err).Errorln("unable to decode response")
-					return
-				}
-				fmt.Println(msgStr)
-			} else {
-				logrus.Errorln("invalid state")
-			}
+			handleFinalResponse(msg, err, "unable to wipe device", messages.MessageType_MessageType_Success)
 		},
 	}
 }

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -1,0 +1,285 @@
+package proxy
+
+import (
+	"errors"
+	"github.com/Sirupsen/logrus"
+	"github.com/fibercrypto/skywallet-go/src/skywallet"
+	"github.com/fibercrypto/skywallet-go/src/skywallet/wire"
+	messages "github.com/fibercrypto/skywallet-protob/go"
+	"sync"
+)
+
+// Sequencer implementation force all messages to be sequential and make the
+// command atomic
+type Sequencer struct {
+	dev skywallet.Devicer
+	m *sync.Mutex
+}
+
+func NewSequencer(dev skywallet.Devicer) skywallet.Devicer {
+	return &Sequencer{dev:dev, m: &sync.Mutex{}}
+}
+
+func (sq *Sequencer) AddressGen(addressN, startIndex uint32, confirmAddress bool, walletType string) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	var pinEnc string
+	msg, err := sq.dev.AddressGen(addressN, startIndex, confirmAddress, walletType)
+	if err != nil {
+		return wire.Message{}, err
+	}
+	for msg.Kind != uint16(messages.MessageType_MessageType_ResponseSkycoinAddress) && msg.Kind != uint16(messages.MessageType_MessageType_Failure) {
+		if msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) {
+			// FIXME use a reader from sq
+			// fmt.Printf("PinMatrixRequest response: ")
+			// fmt.Scanln(&pinEnc)
+			pinAckResponse, err := sq.dev.PinMatrixAck(pinEnc)
+			if err != nil {
+				return wire.Message{}, err
+			}
+			// TODO this log
+			logrus.Errorln("PinMatrixAck response: %s", pinAckResponse)
+			continue
+		}
+
+		if msg.Kind == uint16(messages.MessageType_MessageType_PassphraseRequest) {
+			var passphrase string
+			// FIXME use a reader from sq
+			//fmt.Printf("Input passphrase: ")
+			//fmt.Scanln(&passphrase)
+			passphraseAckResponse, err := sq.dev.PassphraseAck(passphrase)
+			if err != nil {
+				return wire.Message{}, nil
+			}
+			// TODO this log
+			logrus.Errorln("PinMatrixAck response: %s", passphraseAckResponse)
+			continue
+		}
+
+		if msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+			msg, err = sq.dev.ButtonAck()
+			if err != nil {
+				return wire.Message{}, err
+			}
+			continue
+		}
+	}
+	if msg.Kind == uint16(messages.MessageType_MessageType_ResponseSkycoinAddress) {
+		return msg, nil
+	}
+	failMsg, err := skywallet.DecodeFailMsg(msg)
+	if err != nil {
+		return wire.Message{}, err
+	}
+	logrus.WithError(err).Errorln(failMsg)
+	return wire.Message{}, err
+}
+
+func (sq *Sequencer) ApplySettings(usePassphrase *bool, label string, language string) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.ApplySettings(usePassphrase, label, language)
+}
+
+func (sq *Sequencer) Backup() (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.Backup()
+}
+
+func (sq *Sequencer) Cancel() (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.Cancel()
+}
+
+func (sq *Sequencer) CheckMessageSignature(message, signature, address string) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.CheckMessageSignature(message, signature, address)
+}
+
+func (sq *Sequencer) ChangePin(removePin *bool) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.ChangePin(removePin)
+}
+
+func (sq *Sequencer) Connected() bool {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.Connected()
+}
+
+func (sq *Sequencer) Available() bool {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.Available()
+}
+
+func (sq *Sequencer) FirmwareUpload(payload []byte, hash [32]byte) error {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.FirmwareUpload(payload, hash)
+}
+
+func (sq *Sequencer) GetFeatures() (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	msg, err := sq.dev.GetFeatures()
+	if err != nil {
+		return wire.Message{}, err
+	}
+	switch msg.Kind {
+	case uint16(messages.MessageType_MessageType_Features):
+		return msg, nil
+	case uint16(messages.MessageType_MessageType_Failure), uint16(messages.MessageType_MessageType_Success):
+		msgData, err := skywallet.DecodeFailMsg(msg)
+		if err != nil {
+			return wire.Message{}, err
+		}
+		logrus.Errorln(msgData)
+		return wire.Message{}, err
+	default:
+		logrus.Errorf("received unexpected message type: %s", messages.MessageType(msg.Kind))
+		return wire.Message{}, errors.New("unexpected msg")
+	}
+}
+
+func (sq *Sequencer) GenerateMnemonic(wordCount uint32, usePassphrase bool) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.GenerateMnemonic(wordCount, usePassphrase)
+}
+
+func (sq *Sequencer) Recovery(wordCount uint32, usePassphrase *bool, dryRun bool) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.Recovery(wordCount, usePassphrase, dryRun)
+}
+
+func (sq *Sequencer) SetMnemonic(mnemonic string) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.SetMnemonic(mnemonic)
+}
+
+func (sq *Sequencer) TransactionSign(inputs []*messages.SkycoinTransactionInput, outputs []*messages.SkycoinTransactionOutput, walletType string) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	// TODO interesting
+	//if len(inputs) != len(inputIndex) {
+	//	fmt.Println("Every given input hash should have the an inputIndex")
+	//	return
+	//}
+	//if len(outputs) != len(coins) || len(outputs) != len(hours) {
+	//	fmt.Println("Every given output should have a coin and hour value")
+	//	return
+	//}
+	msg, err := sq.dev.TransactionSign(inputs, outputs, walletType)
+	if err != nil {
+		return wire.Message{}, err
+	}
+	for {
+		logrus.Errorln("msg.Kind", msg.Kind)
+		switch msg.Kind {
+		case uint16(messages.MessageType_MessageType_ResponseTransactionSign):
+			return msg, nil
+		case uint16(messages.MessageType_MessageType_Success):
+			return wire.Message{}, errors.New("should end with ResponseTransactionSign request")
+		case uint16(messages.MessageType_MessageType_ButtonRequest):
+			msg, err = sq.dev.ButtonAck()
+			if err != nil {
+				return wire.Message{}, err
+			}
+		case uint16(messages.MessageType_MessageType_PassphraseRequest):
+			var passphrase string
+			// FIXME
+			//fmt.Printf("Input passphrase: ")
+			//fmt.Scanln(&passphrase)
+			msg, err = sq.dev.PassphraseAck(passphrase)
+			if err != nil {
+				return wire.Message{}, err
+			}
+		case uint16(messages.MessageType_MessageType_PinMatrixRequest):
+			var pinEnc string
+			// FIXME
+			//fmt.Printf("PinMatrixRequest response: ")
+			//fmt.Scanln(&pinEnc)
+			msg, err = sq.dev.PinMatrixAck(pinEnc)
+			if err != nil {
+				return wire.Message{}, err
+			}
+		case uint16(messages.MessageType_MessageType_Failure):
+			failMsg, err := skywallet.DecodeFailMsg(msg)
+			if err != nil {
+				return wire.Message{}, err
+			}
+			logrus.WithError(err).Errorln(failMsg)
+			return wire.Message{}, errors.New("failed")
+		default:
+			logrus.Errorf("received unexpected message type: %s", messages.MessageType(msg.Kind))
+			return wire.Message{}, errors.New("unexpected message")
+		}
+	}
+}
+
+func (sq *Sequencer) SignMessage(addressN, addressIndex int, message string, walletType string) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.SignMessage(addressN, addressIndex, message, walletType)
+}
+
+func (sq *Sequencer) Wipe() (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.Wipe()
+}
+
+func (sq *Sequencer) PinMatrixAck(p string) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.PinMatrixAck(p)
+}
+
+func (sq *Sequencer) WordAck(word string) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.WordAck(word)
+}
+
+func (sq *Sequencer) PassphraseAck(passphrase string) (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.PassphraseAck(passphrase)
+}
+
+func (sq *Sequencer) ButtonAck() (wire.Message, error) {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.ButtonAck()
+}
+
+func (sq *Sequencer) SetAutoPressButton(simulateButtonPress bool, simulateButtonType skywallet.ButtonType) error {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.SetAutoPressButton(simulateButtonPress, simulateButtonType)
+}
+
+func (sq *Sequencer) Close() {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	sq.dev.Close()
+}
+
+func (sq *Sequencer) Connect() error {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.Connect()
+}
+
+func (sq *Sequencer) Disconnect() error {
+	sq.m.Lock()
+	defer sq.m.Unlock()
+	return sq.dev.Disconnect()
+}

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -3,7 +3,7 @@ package proxy //nolint goimports
 import (
 	"errors"
 	"fmt"
-	"github.com/micro/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"io/ioutil"
 	"sync"
 

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -92,13 +92,10 @@ func (sq *Sequencer) handleInputInteraction(msg wire.Message) (wire.Message, err
 			return msg, err
 		}
 	} else if msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
-		msg, err = sq.dev.ButtonAck()
-		msgStr, err := handleResponse(msg, err)
-		if err != nil {
+		if msg, err = sq.dev.ButtonAck(); err != nil {
 			sq.log.WithError(err).Errorln("handling message failed")
 			return msg, err
 		}
-		sq.log.Infoln("ButtonAck response", msgStr)
 	}
 	return msg, nil
 }

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -205,7 +205,7 @@ func (sq *Sequencer) CheckMessageSignature(message, signature, address string) (
 func (sq *Sequencer) ChangePin(removePin *bool) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
-	msg, err := sq.dev.ChangePin(new(bool))
+	msg, err := sq.dev.ChangePin(removePin)
 	msg, err = sq.handleFirstCommandResponse(messages.MessageType_MessageType_Success, "change pin", err, msg)
 	if err != nil {
 		return wire.Message{}, err

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -2,7 +2,7 @@ package proxy
 
 import (
 	"errors"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/fibercrypto/skywallet-go/src/skywallet"
 	"github.com/fibercrypto/skywallet-go/src/skywallet/wire"
 	messages "github.com/fibercrypto/skywallet-protob/go"

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -223,10 +223,10 @@ func (sq *Sequencer) ChangePin(removePin *bool) (wire.Message, error) {
 	defer sq.Unlock()
 	msg, err := sq.dev.ChangePin(new(bool))
 	if err != nil {
-		sq.log.WithError(err).Errorln("backup: sending message failed")
+		sq.log.WithError(err).Errorln("change pin: sending message failed")
 		return wire.Message{}, err
 	}
-	for msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+	for msg.Kind != uint16(messages.MessageType_MessageType_Failure) && msg.Kind != uint16(messages.MessageType_MessageType_Success) {
 		if msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) || msg.Kind == uint16(messages.MessageType_MessageType_PassphraseRequest) || msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
 			if msg, err = sq.handleInputInteraction(msg); err != nil {
 				sq.log.WithError(err).Errorln("error handling interaction")

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -292,7 +292,7 @@ func (sq *Sequencer) GetFeatures() (wire.Message, error) {
 		sq.log.WithError(err).Errorln("get features: sending message failed")
 		return wire.Message{}, err
 	}
-	for msg.Kind != uint16(messages.MessageType_MessageType_Failure) && msg.Kind != uint16(messages.MessageType_MessageType_Success) {
+	for msg.Kind != uint16(messages.MessageType_MessageType_Failure) && msg.Kind != uint16(messages.MessageType_MessageType_Features) {
 		if msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) || msg.Kind == uint16(messages.MessageType_MessageType_PassphraseRequest) || msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
 			if msg, err = sq.handleInputInteraction(msg); err != nil {
 				sq.log.WithError(err).Errorln("error handling interaction")
@@ -300,13 +300,8 @@ func (sq *Sequencer) GetFeatures() (wire.Message, error) {
 			}
 		}
 	}
-	if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-		respMsg, err := skywallet.DecodeSuccessMsg(msg)
-		if err != nil {
-			return wire.Message{}, err
-		}
-		logrus.WithError(err).Errorln(respMsg)
-		return wire.Message{}, nil
+	if msg.Kind == uint16(messages.MessageType_MessageType_Features) {
+		return msg, nil
 	}
 	if msg.Kind == uint16(messages.MessageType_MessageType_Failure) {
 		respMsg, err := skywallet.DecodeFailMsg(msg)

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -267,7 +267,33 @@ func (sq *Sequencer) GetFeatures() (wire.Message, error) {
 func (sq *Sequencer) GenerateMnemonic(wordCount uint32, usePassphrase bool) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
-	return sq.dev.GenerateMnemonic(wordCount, usePassphrase)
+	msg, err := sq.dev.GenerateMnemonic(wordCount, usePassphrase)
+	if err != nil {
+		return wire.Message{}, err
+	}
+	if msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+		msg, err = sq.dev.ButtonAck()
+		if err != nil {
+			return wire.Message{}, err
+		}
+	}
+	if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
+		_, err := skywallet.DecodeSuccessMsg(msg)
+		if err != nil {
+			return wire.Message{}, err
+		}
+		return msg, nil
+	}
+	if msg.Kind == uint16(messages.MessageType_MessageType_Failure) {
+		msgStr, err := skywallet.DecodeFailMsg(msg)
+		if err != nil {
+			return wire.Message{}, err
+		}
+		logrus.WithError(err).Errorln(msgStr)
+		return wire.Message{}, errors.New(msgStr)
+	}
+	logrus.WithField("msg", msg).Errorln("unexpected response from device")
+	return wire.Message{}, errors.New("unexpected response from device")
 }
 
 func (sq *Sequencer) Recovery(wordCount uint32, usePassphrase *bool, dryRun bool) (wire.Message, error) {

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -112,6 +112,9 @@ func (sq *Sequencer) AddressGen(addressN, startIndex uint32, confirmAddress bool
 			}
 		}
 	}
+	if msg.Kind == uint16(messages.MessageType_MessageType_SkycoinAddress) {
+		return msg, nil
+	}
 	if msg.Kind == uint16(messages.MessageType_MessageType_ResponseSkycoinAddress) {
 		return msg, nil
 	} else if msg.Kind == uint16(messages.MessageType_MessageType_Failure) {

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -138,9 +138,16 @@ func (sq *Sequencer) ApplySettings(usePassphrase *bool, label string, language s
 		return wire.Message{}, err
 	}
 	for msg.Kind != uint16(messages.MessageType_MessageType_Failure) && msg.Kind != uint16(messages.MessageType_MessageType_Success) {
-		if msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) || msg.Kind == uint16(messages.MessageType_MessageType_PassphraseRequest) || msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+		if msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) || msg.Kind == uint16(messages.MessageType_MessageType_PassphraseRequest) {
 			if msg, err = sq.handleInputInteraction(msg); err != nil {
 				sq.log.WithError(err).Errorln("error handling interaction")
+				return wire.Message{}, err
+			}
+		}
+		for msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+			msg, err = sq.dev.ButtonAck()
+			if err != nil {
+				sq.log.WithError(err).Errorln("unable to apply settings")
 				return wire.Message{}, err
 			}
 		}

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -214,24 +214,17 @@ func (sq *Sequencer) CheckMessageSignature(message, signature, address string) (
 func (sq *Sequencer) ChangePin(removePin *bool) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
-	var pinEnc string
 	msg, err := sq.dev.ChangePin(new(bool))
 	if err != nil {
+		sq.log.WithError(err).Errorln("backup: sending message failed")
 		return wire.Message{}, err
 	}
-	if msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
-		msg, err = sq.dev.ButtonAck()
-		if err != nil {
-			return wire.Message{}, err
-		}
-	}
-	for msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) {
-		// FIXME use a reader from sq
-		//fmt.Printf("PinMatrixRequest response: ")
-		//fmt.Scanln(&pinEnc)
-		msg, err = sq.dev.PinMatrixAck(pinEnc)
-		if err != nil {
-			return wire.Message{}, err
+	for msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+		if msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) || msg.Kind == uint16(messages.MessageType_MessageType_PassphraseRequest) || msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+			if msg, err = sq.handleInputInteraction(msg); err != nil {
+				sq.log.WithError(err).Errorln("error handling interaction")
+				return wire.Message{}, err
+			}
 		}
 	}
 	if msg.Kind == uint16(messages.MessageType_MessageType_Success) {

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -335,19 +335,18 @@ func (sq *Sequencer) GenerateMnemonic(wordCount uint32, usePassphrase bool) (wir
 	defer sq.Unlock()
 	msg, err := sq.dev.GenerateMnemonic(wordCount, usePassphrase)
 	if err != nil {
+		sq.log.WithError(err).Errorln("generate mnemonic: sending message failed")
 		return wire.Message{}, err
 	}
-	if msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
-		msg, err = sq.dev.ButtonAck()
-		if err != nil {
-			return wire.Message{}, err
+	for msg.Kind != uint16(messages.MessageType_MessageType_Failure) && msg.Kind != uint16(messages.MessageType_MessageType_Success) {
+		if msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) || msg.Kind == uint16(messages.MessageType_MessageType_PassphraseRequest) || msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+			if msg, err = sq.handleInputInteraction(msg); err != nil {
+				sq.log.WithError(err).Errorln("error handling interaction")
+				return wire.Message{}, err
+			}
 		}
 	}
 	if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-		_, err := skywallet.DecodeSuccessMsg(msg)
-		if err != nil {
-			return wire.Message{}, err
-		}
 		return msg, nil
 	}
 	if msg.Kind == uint16(messages.MessageType_MessageType_Failure) {
@@ -355,10 +354,10 @@ func (sq *Sequencer) GenerateMnemonic(wordCount uint32, usePassphrase bool) (wir
 		if err != nil {
 			return wire.Message{}, err
 		}
-		logrus.WithError(err).Errorln(msgStr)
+		sq.log.Errorln(msgStr)
 		return wire.Message{}, errors.New(msgStr)
 	}
-	logrus.WithField("msg", msg).Errorln("unexpected response from device")
+	sq.log.WithField("msg", msg).Errorln("unexpected response from device")
 	return wire.Message{}, errors.New("unexpected response from device")
 }
 

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -13,16 +13,16 @@ import (
 // command atomic
 type Sequencer struct {
 	dev skywallet.Devicer
-	m *sync.Mutex
+	sync.Mutex
 }
 
 func NewSequencer(dev skywallet.Devicer) skywallet.Devicer {
-	return &Sequencer{dev:dev, m: &sync.Mutex{}}
+	return &Sequencer{dev:dev}
 }
 
 func (sq *Sequencer) AddressGen(addressN, startIndex uint32, confirmAddress bool, walletType string) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	var pinEnc string
 	msg, err := sq.dev.AddressGen(addressN, startIndex, confirmAddress, walletType)
 	if err != nil {
@@ -76,56 +76,56 @@ func (sq *Sequencer) AddressGen(addressN, startIndex uint32, confirmAddress bool
 }
 
 func (sq *Sequencer) ApplySettings(usePassphrase *bool, label string, language string) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.ApplySettings(usePassphrase, label, language)
 }
 
 func (sq *Sequencer) Backup() (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.Backup()
 }
 
 func (sq *Sequencer) Cancel() (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.Cancel()
 }
 
 func (sq *Sequencer) CheckMessageSignature(message, signature, address string) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.CheckMessageSignature(message, signature, address)
 }
 
 func (sq *Sequencer) ChangePin(removePin *bool) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.ChangePin(removePin)
 }
 
 func (sq *Sequencer) Connected() bool {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.Connected()
 }
 
 func (sq *Sequencer) Available() bool {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.Available()
 }
 
 func (sq *Sequencer) FirmwareUpload(payload []byte, hash [32]byte) error {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.FirmwareUpload(payload, hash)
 }
 
 func (sq *Sequencer) GetFeatures() (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	msg, err := sq.dev.GetFeatures()
 	if err != nil {
 		return wire.Message{}, err
@@ -147,26 +147,26 @@ func (sq *Sequencer) GetFeatures() (wire.Message, error) {
 }
 
 func (sq *Sequencer) GenerateMnemonic(wordCount uint32, usePassphrase bool) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.GenerateMnemonic(wordCount, usePassphrase)
 }
 
 func (sq *Sequencer) Recovery(wordCount uint32, usePassphrase *bool, dryRun bool) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.Recovery(wordCount, usePassphrase, dryRun)
 }
 
 func (sq *Sequencer) SetMnemonic(mnemonic string) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.SetMnemonic(mnemonic)
 }
 
 func (sq *Sequencer) TransactionSign(inputs []*messages.SkycoinTransactionInput, outputs []*messages.SkycoinTransactionOutput, walletType string) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	// TODO interesting
 	//if len(inputs) != len(inputIndex) {
 	//	fmt.Println("Every given input hash should have the an inputIndex")
@@ -225,61 +225,61 @@ func (sq *Sequencer) TransactionSign(inputs []*messages.SkycoinTransactionInput,
 }
 
 func (sq *Sequencer) SignMessage(addressN, addressIndex int, message string, walletType string) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.SignMessage(addressN, addressIndex, message, walletType)
 }
 
 func (sq *Sequencer) Wipe() (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.Wipe()
 }
 
 func (sq *Sequencer) PinMatrixAck(p string) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.PinMatrixAck(p)
 }
 
 func (sq *Sequencer) WordAck(word string) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.WordAck(word)
 }
 
 func (sq *Sequencer) PassphraseAck(passphrase string) (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.PassphraseAck(passphrase)
 }
 
 func (sq *Sequencer) ButtonAck() (wire.Message, error) {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.ButtonAck()
 }
 
 func (sq *Sequencer) SetAutoPressButton(simulateButtonPress bool, simulateButtonType skywallet.ButtonType) error {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.SetAutoPressButton(simulateButtonPress, simulateButtonType)
 }
 
 func (sq *Sequencer) Close() {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	sq.dev.Close()
 }
 
 func (sq *Sequencer) Connect() error {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.Connect()
 }
 
 func (sq *Sequencer) Disconnect() error {
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	sq.Lock()
+	defer sq.Unlock()
 	return sq.dev.Disconnect()
 }

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -171,10 +171,17 @@ func (sq *Sequencer) Backup() (wire.Message, error) {
 		sq.log.WithError(err).Errorln("backup: sending message failed")
 		return wire.Message{}, err
 	}
-	for msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
-		if msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) || msg.Kind == uint16(messages.MessageType_MessageType_PassphraseRequest) || msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+	for msg.Kind != uint16(messages.MessageType_MessageType_Failure) && msg.Kind != uint16(messages.MessageType_MessageType_Success) {
+		if msg.Kind == uint16(messages.MessageType_MessageType_PinMatrixRequest) || msg.Kind == uint16(messages.MessageType_MessageType_PassphraseRequest) {
 			if msg, err = sq.handleInputInteraction(msg); err != nil {
 				sq.log.WithError(err).Errorln("error handling interaction")
+				return wire.Message{}, err
+			}
+		}
+		for msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+			msg, err = sq.dev.ButtonAck()
+			if err != nil {
+				sq.log.WithError(err).Errorln("unable to create backup")
 				return wire.Message{}, err
 			}
 		}

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -2,24 +2,36 @@ package proxy //nolint goimports
 
 import (
 	"errors"
+	"io/ioutil"
 	"sync"
 
 	"github.com/fibercrypto/skywallet-go/src/skywallet"
 	"github.com/fibercrypto/skywallet-go/src/skywallet/wire"
 	messages "github.com/fibercrypto/skywallet-protob/go"
 	"github.com/sirupsen/logrus"
+	"github.com/skycoin/skycoin/src/util/logging"
 )
 
 // Sequencer implementation force all messages to be sequential and make the
 // command atomic
 type Sequencer struct {
-	dev skywallet.Devicer
 	sync.Mutex
+	log *logging.MasterLogger
+	logCli *logging.MasterLogger
+	dev skywallet.Devicer
 }
 
-// NewSequencer create a bew sequencer instance
-func NewSequencer(dev skywallet.Devicer) skywallet.Devicer {
-	return &Sequencer{dev: dev}
+// NewSequencer create a new sequencer instance
+func NewSequencer(dev skywallet.Devicer, cliSpeechless bool) skywallet.Devicer {
+	sq := &Sequencer{
+		log: logging.NewMasterLogger(),
+		logCli: logging.NewMasterLogger(),
+		dev: dev,
+	}
+	if cliSpeechless {
+		sq.logCli.Out = ioutil.Discard
+	}
+	return sq
 }
 
 // AddressGen forward the call to Device and handle all the consecutive command as an

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -347,7 +347,32 @@ func (sq *Sequencer) Recovery(wordCount uint32, usePassphrase *bool, dryRun bool
 func (sq *Sequencer) SetMnemonic(mnemonic string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
-	return sq.dev.SetMnemonic(mnemonic)
+	msg, err := sq.dev.SetMnemonic(mnemonic)
+	if err != nil {
+		return wire.Message{}, err
+	}
+	if msg.Kind == uint16(messages.MessageType_MessageType_ButtonRequest) {
+		msg, err = sq.dev.ButtonAck()
+		if err != nil {
+			return wire.Message{}, err
+		}
+	}
+	if msg.Kind == uint16(messages.MessageType_MessageType_Failure) {
+		msgStr, err := skywallet.DecodeFailMsg(msg)
+		if err != nil {
+			return wire.Message{}, err
+		}
+		logrus.WithError(err).Errorln(msgStr)
+	}
+	if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
+		_, err := skywallet.DecodeSuccessMsg(msg)
+		if err != nil {
+			return wire.Message{}, err
+		}
+		return msg, nil
+	}
+	logrus.WithField("msg", msg).Errorln("unexpected response from device")
+	return wire.Message{}, errors.New("unexpected response from device")
 }
 
 func (sq *Sequencer) TransactionSign(inputs []*messages.SkycoinTransactionInput, outputs []*messages.SkycoinTransactionOutput, walletType string) (wire.Message, error) {

--- a/src/integration/proxy/sequencer.go
+++ b/src/integration/proxy/sequencer.go
@@ -1,12 +1,13 @@
-package proxy
+package proxy //nolint goimports
 
 import (
 	"errors"
-	"github.com/sirupsen/logrus"
+	"sync"
+
 	"github.com/fibercrypto/skywallet-go/src/skywallet"
 	"github.com/fibercrypto/skywallet-go/src/skywallet/wire"
 	messages "github.com/fibercrypto/skywallet-protob/go"
-	"sync"
+	"github.com/sirupsen/logrus"
 )
 
 // Sequencer implementation force all messages to be sequential and make the
@@ -16,10 +17,13 @@ type Sequencer struct {
 	sync.Mutex
 }
 
+// NewSequencer create a bew sequencer instance
 func NewSequencer(dev skywallet.Devicer) skywallet.Devicer {
-	return &Sequencer{dev:dev}
+	return &Sequencer{dev: dev}
 }
 
+// AddressGen forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) AddressGen(addressN, startIndex uint32, confirmAddress bool, walletType string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -75,6 +79,8 @@ func (sq *Sequencer) AddressGen(addressN, startIndex uint32, confirmAddress bool
 	return wire.Message{}, err
 }
 
+// ApplySettings forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) ApplySettings(usePassphrase *bool, label string, language string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -95,7 +101,8 @@ func (sq *Sequencer) ApplySettings(usePassphrase *bool, label string, language s
 			// FIXME use a reader from sq
 			//fmt.Printf("PinMatrixRequest response: ")
 			//fmt.Scanln(&pinEnc)
-			/*pinAckResponse*/_, err := sq.dev.PinMatrixAck(pinEnc)
+			/*pinAckResponse*/
+			_, err := sq.dev.PinMatrixAck(pinEnc)
 			if err != nil {
 				return wire.Message{}, err
 			}
@@ -123,6 +130,8 @@ func (sq *Sequencer) ApplySettings(usePassphrase *bool, label string, language s
 	return wire.Message{}, errors.New("unexpected response from device")
 }
 
+// Backup forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) Backup() (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -168,18 +177,22 @@ func (sq *Sequencer) Backup() (wire.Message, error) {
 	return wire.Message{}, errors.New("error in backup operation")
 }
 
+// Cancel forward the call to Device
 func (sq *Sequencer) Cancel() (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.Cancel()
 }
 
+// CheckMessageSignature forward the call to Device
 func (sq *Sequencer) CheckMessageSignature(message, signature, address string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.CheckMessageSignature(message, signature, address)
 }
 
+// ChangePin forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) ChangePin(removePin *bool) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -220,27 +233,32 @@ func (sq *Sequencer) ChangePin(removePin *bool) (wire.Message, error) {
 		return wire.Message{}, errors.New(respMsg)
 	}
 	logrus.WithField("msg", msg).Errorln("unexpected response from device")
-    return wire.Message{}, errors.New("unexpected response from device")
+	return wire.Message{}, errors.New("unexpected response from device")
 }
 
+// Connected forward the call to Device
 func (sq *Sequencer) Connected() bool {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.Connected()
 }
 
+// Available forward the call to Device
 func (sq *Sequencer) Available() bool {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.Available()
 }
 
+// FirmwareUpload forward the call to Device
 func (sq *Sequencer) FirmwareUpload(payload []byte, hash [32]byte) error {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.FirmwareUpload(payload, hash)
 }
 
+// GetFeatures forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) GetFeatures() (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -264,6 +282,8 @@ func (sq *Sequencer) GetFeatures() (wire.Message, error) {
 	}
 }
 
+// GenerateMnemonic forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) GenerateMnemonic(wordCount uint32, usePassphrase bool) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -296,6 +316,8 @@ func (sq *Sequencer) GenerateMnemonic(wordCount uint32, usePassphrase bool) (wir
 	return wire.Message{}, errors.New("unexpected response from device")
 }
 
+// Recovery forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) Recovery(wordCount uint32, usePassphrase *bool, dryRun bool) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -344,6 +366,8 @@ func (sq *Sequencer) Recovery(wordCount uint32, usePassphrase *bool, dryRun bool
 	return wire.Message{}, errors.New("unexpected response from device")
 }
 
+// SetMnemonic forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) SetMnemonic(mnemonic string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -375,6 +399,8 @@ func (sq *Sequencer) SetMnemonic(mnemonic string) (wire.Message, error) {
 	return wire.Message{}, errors.New("unexpected response from device")
 }
 
+// TransactionSign forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) TransactionSign(inputs []*messages.SkycoinTransactionInput, outputs []*messages.SkycoinTransactionOutput, walletType string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -435,6 +461,8 @@ func (sq *Sequencer) TransactionSign(inputs []*messages.SkycoinTransactionInput,
 	}
 }
 
+// SignMessage forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) SignMessage(addressN, addressIndex int, message string, walletType string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -491,6 +519,8 @@ func (sq *Sequencer) SignMessage(addressN, addressIndex int, message string, wal
 	return wire.Message{}, errors.New("unexpected response from device")
 }
 
+// Wipe forward the call to Device and handle all the consecutive command as an
+// atomic sequence
 func (sq *Sequencer) Wipe() (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
@@ -523,48 +553,56 @@ func (sq *Sequencer) Wipe() (wire.Message, error) {
 	return wire.Message{}, errors.New("unexpected response from device")
 }
 
+// PinMatrixAck forward the call to Device
 func (sq *Sequencer) PinMatrixAck(p string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.PinMatrixAck(p)
 }
 
+// WordAck forward the call to Device
 func (sq *Sequencer) WordAck(word string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.WordAck(word)
 }
 
+// PassphraseAck forward the call to Device
 func (sq *Sequencer) PassphraseAck(passphrase string) (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.PassphraseAck(passphrase)
 }
 
+// ButtonAck forward the call to Device
 func (sq *Sequencer) ButtonAck() (wire.Message, error) {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.ButtonAck()
 }
 
+// SetAutoPressButton forward the call to Device
 func (sq *Sequencer) SetAutoPressButton(simulateButtonPress bool, simulateButtonType skywallet.ButtonType) error {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.SetAutoPressButton(simulateButtonPress, simulateButtonType)
 }
 
+// Close forward the call to Device
 func (sq *Sequencer) Close() {
 	sq.Lock()
 	defer sq.Unlock()
 	sq.dev.Close()
 }
 
+// Connect forward the call to Device
 func (sq *Sequencer) Connect() error {
 	sq.Lock()
 	defer sq.Unlock()
 	return sq.dev.Connect()
 }
 
+// Disconnect forward the call to Device
 func (sq *Sequencer) Disconnect() error {
 	sq.Lock()
 	defer sq.Unlock()

--- a/src/skywallet/skywallet.go
+++ b/src/skywallet/skywallet.go
@@ -923,7 +923,7 @@ func (d *Device) PinMatrixAck(p string) (wire.Message, error) {
 	}
 	defer d.Disconnect()
 
-	log.Printf("Setting pin: %s\n", p)
+	log.Printf("Setting pin %s\n", p)
 
 	pinMatrixChunks, err := MessagePinMatrixAck(p)
 	if err != nil {


### PR DESCRIPTION
Fixes #163 

Changes:
- Add `Sequencer` as a `Devicer` implementation that forces all commands to be atomic.

Does this change need to mentioned in CHANGELOG.md?
yes

Requires changes in protobuf specs?
no
related to PR https://github.com/fibercrypto/fibercryptowallet/pull/253

Requires testing
yes